### PR TITLE
Option of not duplicating data in storage 

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table/DynamicTableEntity.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/DynamicTableEntity.cs
@@ -32,45 +32,44 @@ namespace CoreHelpers.WindowsAzure.Storage.Table
 
 		public string ETag { get; set; }
 
-		public string PartitionKey
-		{
-			get
-			{
-				if ( _entityMapper.PartitionKeyFormat.Contains("{{") && _entityMapper.PartitionKeyFormat.Contains("}}")) 
-				{
-					var template = Handlebars.Compile(_entityMapper.PartitionKeyFormat);
-					return template(_srcModel);
-				} else {
-					var propertyInfo = _srcModel.GetType().GetRuntimeProperty(_entityMapper.PartitionKeyFormat);
-					return propertyInfo.GetValue(_srcModel) as String;
-				}					
-			}
+        public string PartitionKey {
+            get => GetTableStorageDefaultProperty<string>(_entityMapper.PartitionKeyFormat);
+            set => SetTableStorageDefaultProperty(value, _entityMapper.PartitionKeyFormat);
+        }
 
-			set
-			{
-				// we don't need to do anything 
-			}
-		}
+        public string RowKey {
+            get => GetTableStorageDefaultProperty<string>(_entityMapper.RowKeyFormat);
+            set => SetTableStorageDefaultProperty(value, _entityMapper.RowKeyFormat);
+        }
 
-		public string RowKey
-		{
-			get
-			{
-				if ( _entityMapper.RowKeyFormat.Contains("{{") && _entityMapper.RowKeyFormat.Contains("}}")) 
-				{
-					var template = Handlebars.Compile(_entityMapper.RowKeyFormat);
-					return template(_srcModel);
-				} else {
-					var propertyInfo = _srcModel.GetType().GetRuntimeProperty(_entityMapper.RowKeyFormat);
-					return propertyInfo.GetValue(_srcModel) as String;
-				}				
-			}
+        private S GetTableStorageDefaultProperty<S>(string format) where S : class
+        {
+            if (typeof(S) == typeof(string) && format.Contains("{{") && format.Contains("}}"))
+            {
+                var template = Handlebars.Compile(format);
+                return template(_srcModel) as S;
+            }
+            else
+            {
+                var propertyInfo = _srcModel.GetType().GetRuntimeProperty(format);
+                return propertyInfo.GetValue(_srcModel) as S;
+            }
+        }
 
-			set
-			{
-				// we don't need to do anything 
-			}
-		}
+        private void SetTableStorageDefaultProperty<S>(S value, string format)
+        {
+            if (!(format.Contains("{{") && format.Contains("}}")))
+            {
+                var propertyInfo = _srcModel.GetType().GetRuntimeProperty(format);
+                // Only do this if we explicitly ignore the property from the other read methods
+                if (propertyInfo?.GetCustomAttribute(typeof(IgnorePropertyAttribute)) != null)
+                {
+                    var setter = propertyInfo.GetSetMethod();
+                    if (setter != null && !setter.IsStatic)
+                        propertyInfo.SetValue(_srcModel, value);
+                }
+            }
+        }
 
 		public DateTimeOffset Timestamp { get; set; }
 

--- a/CoreHelpers.WindowsAzure.Storage.Table/DynamicTableEntity.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/DynamicTableEntity.cs
@@ -33,13 +33,13 @@ namespace CoreHelpers.WindowsAzure.Storage.Table
 		public string ETag { get; set; }
 
         public string PartitionKey {
-            get => GetTableStorageDefaultProperty<string>(_entityMapper.PartitionKeyFormat);
-            set => SetTableStorageDefaultProperty<string, PartitionKeyAttribute>(value);
+            get { return GetTableStorageDefaultProperty<string>(_entityMapper.PartitionKeyFormat); }
+            set { SetTableStorageDefaultProperty<string, PartitionKeyAttribute>(value); }
         }
 
         public string RowKey {
-            get => GetTableStorageDefaultProperty<string>(_entityMapper.RowKeyFormat);
-            set => SetTableStorageDefaultProperty<string, RowKeyAttribute>(value);
+            get { return GetTableStorageDefaultProperty<string>(_entityMapper.RowKeyFormat); }
+            set { SetTableStorageDefaultProperty<string, RowKeyAttribute>(value); }
         }
 
         private S GetTableStorageDefaultProperty<S>(string format) where S : class

--- a/CoreHelpers.WindowsAzure.Storage.Table/DynamicTableEntity.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/DynamicTableEntity.cs
@@ -34,12 +34,12 @@ namespace CoreHelpers.WindowsAzure.Storage.Table
 
         public string PartitionKey {
             get => GetTableStorageDefaultProperty<string>(_entityMapper.PartitionKeyFormat);
-            set => SetTableStorageDefaultProperty(value, _entityMapper.PartitionKeyFormat);
+            set => SetTableStorageDefaultProperty<string, PartitionKeyAttribute>(value);
         }
 
         public string RowKey {
             get => GetTableStorageDefaultProperty<string>(_entityMapper.RowKeyFormat);
-            set => SetTableStorageDefaultProperty(value, _entityMapper.RowKeyFormat);
+            set => SetTableStorageDefaultProperty<string, RowKeyAttribute>(value);
         }
 
         private S GetTableStorageDefaultProperty<S>(string format) where S : class
@@ -56,17 +56,15 @@ namespace CoreHelpers.WindowsAzure.Storage.Table
             }
         }
 
-        private void SetTableStorageDefaultProperty<S>(S value, string format)
+        private void SetTableStorageDefaultProperty<S, A>(S value) where A : Attribute
         {
-            if (!(format.Contains("{{") && format.Contains("}}")))
+            foreach (var property in _srcModel.GetType()?.GetRuntimeProperties())
             {
-                var propertyInfo = _srcModel.GetType().GetRuntimeProperty(format);
-                // Only do this if we explicitly ignore the property from the other read methods
-                if (propertyInfo?.GetCustomAttribute(typeof(IgnorePropertyAttribute)) != null)
+                if (property.GetCustomAttribute<A>() != null && property?.GetCustomAttribute<IgnorePropertyAttribute>() != null)
                 {
-                    var setter = propertyInfo.GetSetMethod();
+                    var setter = property.GetSetMethod();
                     if (setter != null && !setter.IsStatic)
-                        propertyInfo.SetValue(_srcModel, value);
+                        property.SetValue(_srcModel, value);
                 }
             }
         }


### PR DESCRIPTION
Added the option of having a property on a poco bound to a table storage as rowkey or partitionkey without duplicating the information with a second column in the storage.

```c# 
[RowKey]
public string ImportantID {get;set;}
```
will by default have the information `ImportantID` loaced in both RowKey and ImportantID properties in tablestorage, adding the `[IgnoreProperty]` will cause the helper to not load the data into the property at all.

This PR will let the property `ImportantID` on the POCO be populated from the RowKey property on the tablestorage model using the following notation;

```c# 
[RowKey]
[IgnoreProperty]
public string ImportantID {get;set;}
```