### PR TITLE
Bugfix: Even for non-missing-table related errors it would try to autocreate

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table/StorageContext.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/StorageContext.cs
@@ -370,20 +370,22 @@ namespace CoreHelpers.WindowsAzure.Storage.Table
 			catch (StorageException ex) 
 			{
 				// check the exception
-				if (!_autoCreateTable || !ex.Message.StartsWith("0:The table specified does not exist", StringComparison.CurrentCulture))
+                if (_autoCreateTable && ex.Message.StartsWith("0:The table specified does not exist", StringComparison.CurrentCulture))
+                {
+				    // try to create the table	
+				    await CreateTableAsync<T>();
+
+				    // retry 
+				    await StoreAsync<T>(storaeOperationType, models);
+                }
+				else
 				{
 					// notify delegate
 					if (_delegate != null)
 						_delegate.OnStored(typeof(T), storaeOperationType, 0, ex);				
 					
 					throw ex;
-				}
-
-				// try to create the table	
-				await CreateTableAsync<T>();
-
-				// retry 
-				await StoreAsync<T>(storaeOperationType, models);					
+				}				
 			}
 		}
 


### PR DESCRIPTION
Additionally the if sentence was a little unclear. I have reordered the exception check and now it is clear when there will be a second try to create the table.