### PR TITLE
Feature: Open up possibility for complex filters

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table/Models/QueryFilter.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Models/QueryFilter.cs
@@ -26,7 +26,7 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Models
         public QueryFilterOperator Operator { get; set; }
         public QueryFilterType FilterType { get; set;  }
 
-        public string FilterString {
+        public virtual string FilterString {
             get {
                 var filterOperation = QueryComparisons.Equal;
                 switch (Operator)

--- a/CoreHelpers.WindowsAzure.Storage.Table/Models/QueryFilter.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Models/QueryFilter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.WindowsAzure.Storage.Table;
+using System;
 namespace CoreHelpers.WindowsAzure.Storage.Table.Models
 {
     public enum QueryFilterOperator
@@ -24,5 +25,33 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Models
         public string Value { get; set;  }
         public QueryFilterOperator Operator { get; set; }
         public QueryFilterType FilterType { get; set;  }
+
+        public string FilterString {
+            get {
+                var filterOperation = QueryComparisons.Equal;
+                switch (Operator)
+                {
+                    case QueryFilterOperator.Equal:
+                        filterOperation = QueryComparisons.Equal;
+                        break;
+                    case QueryFilterOperator.NotEqual:
+                        filterOperation = QueryComparisons.NotEqual;
+                        break;
+                    case QueryFilterOperator.Lower:
+                        filterOperation = QueryComparisons.LessThan;
+                        break;
+                    case QueryFilterOperator.Greater:
+                        filterOperation = QueryComparisons.GreaterThan;
+                        break;
+                    case QueryFilterOperator.LowerEqual:
+                        filterOperation = QueryComparisons.LessThanOrEqual;
+                        break;
+                    case QueryFilterOperator.GreaterEqual:
+                        filterOperation = QueryComparisons.GreaterThanOrEqual;
+                        break;
+                }
+                return TableQuery.GenerateFilterCondition(Property, filterOperation, Value); 
+            }
+        } 
     }
 }

--- a/CoreHelpers.WindowsAzure.Storage.Table/StorageContext.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/StorageContext.cs
@@ -441,31 +441,7 @@ namespace CoreHelpers.WindowsAzure.Storage.Table
                 {
                     foreach (var queryFilter in queryFilters)
                     {
-
-                        var filterOperation = QueryComparisons.Equal;
-                        switch (queryFilter.Operator)
-                        {
-                            case QueryFilterOperator.Equal:
-                                filterOperation = QueryComparisons.Equal;
-                                break;
-                            case QueryFilterOperator.NotEqual:
-                                filterOperation = QueryComparisons.NotEqual;
-                                break;
-                            case QueryFilterOperator.Lower:
-                                filterOperation = QueryComparisons.LessThan;
-                                break;
-                            case QueryFilterOperator.Greater:
-                                filterOperation = QueryComparisons.GreaterThan;
-                                break;
-                            case QueryFilterOperator.LowerEqual:
-                                filterOperation = QueryComparisons.LessThanOrEqual;
-                                break;
-                            case QueryFilterOperator.GreaterEqual:
-                                filterOperation = QueryComparisons.GreaterThanOrEqual;
-                                break;
-                        }
-
-                        var generatedQueryFilter = TableQuery.GenerateFilterCondition(queryFilter.Property, filterOperation, queryFilter.Value);
+                        var generatedQueryFilter = queryFilter.FilterString;
 
                         if (String.IsNullOrEmpty(query.FilterString))
                             query.Where(generatedQueryFilter);


### PR DESCRIPTION
Moving the filterstring generation to the QueryFilter class will decentralize the filter string generation and allow for inherited classes of QueryFilter that can create complex filters (nested filters).

When the filterstring generation is in StorageContext everything is hard coded and very little extendable. With this simple move all users of the package can simply create a new class based on QueryFilter override the FilterString property and customize away.
