### PR TITLE
Preserve stacktrace on re-throw

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table/Services/DataExportService.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Services/DataExportService.cs
@@ -83,9 +83,9 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Services
                 wr.WriteEnd();
                 wr.Flush();
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                throw e;
+                throw;
             }
         }
     }

--- a/CoreHelpers.WindowsAzure.Storage.Table/Services/DataImportService.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Services/DataImportService.cs
@@ -124,9 +124,9 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Services
                 await Task.Delay(20000);
                 await CreateAzureTableAsync(table);
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                throw e;
+                throw;
             }
         }
     }


### PR DESCRIPTION
I want to add exception handling and logging into the AzureStorageTableBackup project that uses the AzureStorageTable nuget. In case of an error in the AzureStorageTable code, re-throwing an exception with `throw e` would destroy the stack trace and I would lose valuable information.