### PR TITLE
Feature: Handle nullable datatypes from store, and enums

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table/Extensions/PropertyInfoSetValueFromEntityProperty.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Extensions/PropertyInfoSetValueFromEntityProperty.cs
@@ -28,12 +28,16 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Extensions
 				switch (entityProperty.PropertyType)
 				{
 					case EdmType.String:
-						if (propertyType != typeof(string))
-							break;						
+                        if (propertyType.IsEnum && int.TryParse(entityProperty.StringValue, out var intEnum) && propertyType.IsEnumDefined(intEnum))
+                            property.SetOrAddValue(entity, Enum.ToObject(property.PropertyType, intEnum), isCollection);
+                        else if (propertyType.IsEnum && propertyType.IsEnumDefined(entityProperty.StringValue))
+                            property.SetOrAddValue(entity, Enum.ToObject(property.PropertyType, entityProperty.StringValue), isCollection);
 
-						property.SetOrAddValue(entity, entityProperty.StringValue, isCollection);
-						break;
-					case EdmType.Binary:
+                        else if (propertyType == typeof(string))
+                            property.SetOrAddValue(entity, entityProperty.StringValue, isCollection);
+
+                        break;
+                    case EdmType.Binary:
 						if (propertyType != typeof(byte[]))						
 							break;						
 

--- a/CoreHelpers.WindowsAzure.Storage.Table/Extensions/PropertyInfoSetValueFromEntityProperty.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Extensions/PropertyInfoSetValueFromEntityProperty.cs
@@ -31,7 +31,7 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Extensions
                         if (propertyType.IsEnum && int.TryParse(entityProperty.StringValue, out var intEnum) && propertyType.IsEnumDefined(intEnum))
                             property.SetOrAddValue(entity, Enum.ToObject(property.PropertyType, intEnum), isCollection);
                         else if (propertyType.IsEnum && propertyType.IsEnumDefined(entityProperty.StringValue))
-                            property.SetOrAddValue(entity, Enum.ToObject(property.PropertyType, entityProperty.StringValue), isCollection);
+                            property.SetOrAddValue(entity, Enum.Parse(propertyType, entityProperty.StringValue), isCollection);
 
                         else if (propertyType == typeof(string))
                             property.SetOrAddValue(entity, entityProperty.StringValue, isCollection);

--- a/CoreHelpers.WindowsAzure.Storage.Table/Extensions/PropertyInfoSetValueFromEntityProperty.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Extensions/PropertyInfoSetValueFromEntityProperty.cs
@@ -24,8 +24,12 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Extensions
 				// handle colleciton s
 				if (isCollection)
 					propertyType = property.PropertyType.GenericTypeArguments[0];
-									
-				switch (entityProperty.PropertyType)
+
+                var nullableUnderlyingType = Nullable.GetUnderlyingType(propertyType);
+                if (nullableUnderlyingType != null)
+                    propertyType = nullableUnderlyingType;
+
+                switch (entityProperty.PropertyType)
 				{
 					case EdmType.String:
                         if (propertyType.IsEnum && int.TryParse(entityProperty.StringValue, out var intEnum) && propertyType.IsEnumDefined(intEnum))

--- a/CoreHelpers.WindowsAzure.Storage.Table/Extensions/PropertyInfoSetValueFromEntityProperty.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Extensions/PropertyInfoSetValueFromEntityProperty.cs
@@ -32,7 +32,8 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Extensions
                 switch (entityProperty.PropertyType)
 				{
 					case EdmType.String:
-                        if (propertyType.IsEnum && int.TryParse(entityProperty.StringValue, out var intEnum) && propertyType.IsEnumDefined(intEnum))
+                        int intEnum;
+                        if (propertyType.IsEnum && int.TryParse(entityProperty.StringValue, out intEnum) && propertyType.IsEnumDefined(intEnum))
                             property.SetOrAddValue(entity, Enum.ToObject(property.PropertyType, intEnum), isCollection);
                         else if (propertyType.IsEnum && propertyType.IsEnumDefined(entityProperty.StringValue))
                             property.SetOrAddValue(entity, Enum.Parse(propertyType, entityProperty.StringValue), isCollection);


### PR DESCRIPTION
Exactly what it says. in the case of an EdmString datatype the enum will be parsed correctly.

In case of a nullable datatype on the POCO, the underlying object the actual datatype will be parsed.