### PR TITLE
Allow using query filters for non-string types

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table.Tests/Models/DemoEntityQuery.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table.Tests/Models/DemoEntityQuery.cs
@@ -13,6 +13,10 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Tests.Models
         public string StringField { get; set; } = String.Empty;
 
         public bool BoolField { get; set; }
+
+        public DateTime? DateTimeField { get; set; }
+
+        public long LongField { get; set; }
     }
 }
 

--- a/CoreHelpers.WindowsAzure.Storage.Table.Tests/TestEnvironments/UnittestStorageEnvironment.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table.Tests/TestEnvironments/UnittestStorageEnvironment.cs
@@ -1,25 +1,26 @@
-﻿using System;
-using CoreHelpers.WindowsAzure.Storage.Table.Tests.Contracts;
+﻿using CoreHelpers.WindowsAzure.Storage.Table.Tests.Contracts;
 
 namespace CoreHelpers.WindowsAzure.Storage.Table.Tests.TestEnvironments
 {
     public class UnittestStorageEnvironment : ITestEnvironment
-    {       
-        public string ConnectionString {
-            get {
-
+    {
+        public string ConnectionString
+        {
+            get
+            {
                 var connectionString = Environment.GetEnvironmentVariable("STORAGE");
-                if (!String.IsNullOrEmpty(connectionString))
+                if (!string.IsNullOrEmpty(connectionString))
                 {
                     Console.WriteLine("Using environment credentials");
                     return connectionString;
                 }
 
-                var filePath = Environment.ExpandEnvironmentVariables(Path.Combine("%HOME%", ".corehelpers.credentials.txt"));
+                var filePath = Environment.ExpandEnvironmentVariables(Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".corehelpers.credentials.txt"));
                 Console.WriteLine("Using filesystem credentials");
+
                 return File.ReadLines(filePath).First();
             }
         }
     }
 }
-

--- a/CoreHelpers.WindowsAzure.Storage.Table/CoreHelpers.WindowsAzure.Storage.Table.csproj
+++ b/CoreHelpers.WindowsAzure.Storage.Table/CoreHelpers.WindowsAzure.Storage.Table.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="Handlebars.Net" Version="2.1.2" />
     <PackageReference Include="System.Linq.Parallel" Version="4.3.0" />
-    <PackageReference Include="Azure.Data.Tables" Version="12.6.1" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/CoreHelpers.WindowsAzure.Storage.Table/Extensions/QueryFilterExtensions.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Extensions/QueryFilterExtensions.cs
@@ -24,6 +24,7 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Extensions
                 bool b => b.ToString().ToLower(),
                 byte[] bytes => $"binary'{Convert.ToBase64String(bytes)}'",
                 DateTimeOffset offset => $"datetime'{offset.ToUniversalTime():s}Z'",
+                DateTime offset => $"datetime'{offset.ToUniversalTime():s}Z'",
                 double d => d.ToString(CultureInfo.InvariantCulture),
                 Guid guid => $"guid'{guid}'",
                 int i => i.ToString(),


### PR DESCRIPTION
Up until now all data types except `string` and `bool` where non-functional in some way.

This PR tries to support all known azure table storage types when using with the `QueryFilter` class.