### PR TITLE
Store models with a common base in the same table

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table.Tests/ITS030SharedTable.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table.Tests/ITS030SharedTable.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using CoreHelpers.WindowsAzure.Storage.Table.Tests.Extensions;
+using CoreHelpers.WindowsAzure.Storage.Table.Tests.Models;
+using Xunit.DependencyInjection;
+
+namespace CoreHelpers.WindowsAzure.Storage.Table.Tests
+{
+    [Startup(typeof(Startup))]
+    [Collection("Sequential")]
+    public class ITS030SharedTable
+    {
+        private readonly IStorageContext _rootContext;
+
+        public ITS030SharedTable(IStorageContext context)
+        {
+            _rootContext = context;
+
+        }
+
+
+        [Fact]
+        public async Task VerifyGetItem()
+        {
+            using (var scp = _rootContext.CreateChildContext())
+            {
+                // set the tablename context
+                scp.SetTableContext();
+
+                // configure the entity mapper
+                scp.AddAttributeMapper(typeof(MultipleModelsBase));
+
+
+                var model1 = new MultipleModels1() { P = "P1", Contact = "C1", Model1Field = "Model1Field" };
+                var model2 = new MultipleModels2() { P = "P1", Contact = "C2", Model2Field = "Model2Field" };
+
+
+                scp.EnableAutoCreateTable();
+
+                await scp.MergeOrInsertAsync<MultipleModelsBase>(new[] {model1});
+                await scp.MergeOrInsertAsync<MultipleModelsBase>(new[] {model2});
+
+
+                var result1 = await scp.QueryAsync<MultipleModelsBase>("P1", "C1");
+                Assert.Equivalent(model1, result1, true);
+                Assert.IsType<MultipleModels1>(result1);
+
+                var result2 = await scp.QueryAsync<MultipleModelsBase>("P1", "C2");
+                Assert.Equivalent(model2, result2, true);
+                Assert.IsType<MultipleModels2>(result2);
+
+                // cleanup
+                await scp.DropTableAsync<MultipleModelsBase>();
+            }
+        }
+
+    }
+}

--- a/CoreHelpers.WindowsAzure.Storage.Table.Tests/Models/MultipleModels.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table.Tests/Models/MultipleModels.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using CoreHelpers.WindowsAzure.Storage.Table.Attributes;
+
+namespace CoreHelpers.WindowsAzure.Storage.Table.Tests.Models
+{
+
+    [Storable(TypeField = nameof(Type))]
+    public class MultipleModelsBase
+    {
+        [PartitionKey]
+        public string P { get; set; } = "Partition01";
+
+        [RowKey]
+        public string Contact { get; set; } = String.Empty;
+
+    }
+
+	public class MultipleModels1 : MultipleModelsBase
+	{
+        public string Model1Field { get; set; } = String.Empty;
+
+	}
+
+    public class MultipleModels2 : MultipleModelsBase
+    {
+        public string Model2Field { get; set; } = String.Empty;
+
+    }
+
+}

--- a/CoreHelpers.WindowsAzure.Storage.Table/Attributes/StorableAttribute.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Attributes/StorableAttribute.cs
@@ -6,9 +6,17 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Attributes
     public class StorableAttribute : Attribute
     {
         public string Tablename { get; set; }
+
+        public string TypeField { get; set; } = null;
     
         public StorableAttribute() {}
         
+        public StorableAttribute(string Tablename, string TypeField)
+        {
+            this.Tablename = Tablename;
+            this.TypeField = TypeField;
+        }
+
         public StorableAttribute(string Tablename)
         {
             this.Tablename = Tablename;

--- a/CoreHelpers.WindowsAzure.Storage.Table/StoargeEntityMapper.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/StoargeEntityMapper.cs
@@ -9,6 +9,7 @@ namespace CoreHelpers.WindowsAzure.Storage.Table
 		public String RowKeyFormat { get; set; }
         public nVirtualValueEncoding RowKeyEncoding { get; set; }
         public String TableName { get; set; }
+        public string TypeField { get; internal set; }
 
         public StorageEntityMapper() 
         {}

--- a/CoreHelpers.WindowsAzure.Storage.Table/StorageContextAttributeMapping.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/StorageContextAttributeMapping.cs
@@ -62,11 +62,17 @@ namespace CoreHelpers.WindowsAzure.Storage.Table
 
         public void AddAttributeMapper(Type type, String optionalTablenameOverride)
         {
+            string typeField = null;
+
             // get the concrete attribute
             var storableAttribute = type.GetTypeInfo().GetCustomAttribute<StorableAttribute>();
             if (String.IsNullOrEmpty(storableAttribute.Tablename))
             {
                 storableAttribute.Tablename = type.Name;
+            }
+            if (!String.IsNullOrEmpty(storableAttribute.TypeField))
+            {
+                typeField = storableAttribute.TypeField;
             }
 
             // store the neded properties
@@ -111,7 +117,8 @@ namespace CoreHelpers.WindowsAzure.Storage.Table
                 TableName = String.IsNullOrEmpty(optionalTablenameOverride) ? storableAttribute.Tablename : optionalTablenameOverride,
                 PartitionKeyFormat = partitionKeyFormat,
                 RowKeyFormat = rowKeyFormat,
-                RowKeyEncoding = rowKeyEncoding
+                RowKeyEncoding = rowKeyEncoding,
+                TypeField = typeField,
             });
         }
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,56 @@ public class JObjectModel
 }
 ```
 
+## Store Multiple Objects Types in the same Table
+If multiple objects share a common base class, it can be used to store them in the same table. The base class must be decorated with the Storable attribute with the `TypeField` parameter set. It is best practice to NOT include the type field in the model. 
+ 
+```csharp 
+    [Storable(TypeField = "Type")]
+    public class BaseModel
+    {
+        [PartitionKey]
+        public string P { get; set; } = "Partition01";
+
+        [RowKey]
+        public string R { get; set; } = String.Empty;
+
+    }
+
+	public class MultipleModels1 : MultipleModelsBase
+	{
+        public string Model1Field { get; set; } = String.Empty;
+
+	}
+
+    public class MultipleModels2 : MultipleModelsBase
+    {
+        public string Model2Field { get; set; } = String.Empty;
+
+    }
+
+```
+
+When saving and querying it is important to use the base class as the generic type. 
+
+```csharp 
+	using (var storageContext = new StorageContext(storageKey, storageSecret))
+	{
+		storageContext.AddAttributeMapper();
+
+		storageContext.CreateTable<BaseModel>();
+
+		storageContext.MergeOrInsert<BaseModel>(new MultipleModels1() { R = "Row01", Model1Field = "Model1Field" });
+		storageContext.MergeOrInsert<BaseModel>(new MultipleModels2() { R = "Row02", Model2Field = "Model2Field" });
+
+		var result = storageContext.Query<BaseModel>();
+
+		foreach (var r in result)
+		{
+			Console.WriteLine(r.GetType().Name);
+		}
+	}
+```
+
 # Contributing to Azure Storage Table
 Fork as usual and go crazy!
 


### PR DESCRIPTION
Sometimes I have a use for storing multiple models of the same base type in the same table (possibly for listing purposes). This PR solves that by added a type field to the TableEntity and resolving that to build the Queried item.