### PR TITLE
Implement string enum storage via attributes

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table.Tests/ITS025StoreEnum.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table.Tests/ITS025StoreEnum.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using CoreHelpers.WindowsAzure.Storage.Table.Tests.Contracts;
+using CoreHelpers.WindowsAzure.Storage.Table.Tests.Extensions;
+using CoreHelpers.WindowsAzure.Storage.Table.Tests.Models;
+using Xunit.DependencyInjection;
+
+namespace CoreHelpers.WindowsAzure.Storage.Table.Tests
+{
+    [Startup(typeof(Startup))]
+    [Collection("Sequential")]
+    public class ITS025StoreEnum
+    {
+        private readonly IStorageContext _rootContext;
+
+        public ITS025StoreEnum(IStorageContext context)
+        {
+            _rootContext = context;
+        }
+
+        [Fact]
+        public async Task VerifyAttributeMapper()
+        {
+            using (var storageContext = _rootContext.CreateChildContext())
+            {
+                // set the tablename context
+                storageContext.SetTableContext();
+
+                // create a new user
+                var user = new UserModel4() { FirstName = "Egon", LastName = "Mueller", Contact = "em@acme.org", UserType = UserTypeEnum.Pro };
+
+                // ensure we are using the attributes                
+                storageContext.AddAttributeMapper();
+
+                // ensure the table exists                
+                await storageContext.CreateTableAsync<UserModel4>();
+
+                // inser the model                
+                await storageContext.MergeOrInsertAsync<UserModel4>(user);
+
+                // query all                
+                var result = await storageContext.QueryAsync<UserModel4>();
+                Assert.Single(result);
+                Assert.Equal("Egon", result.First().FirstName);
+                Assert.Equal("Mueller", result.First().LastName);
+                Assert.Equal("em@acme.org", result.First().Contact);
+                Assert.Equal(UserTypeEnum.Pro, result.First().UserType);
+
+                // Clean up 
+                await storageContext.DeleteAsync<UserModel4>(result);
+                result = await storageContext.QueryAsync<UserModel4>();
+                Assert.NotNull(result);
+                Assert.Empty(result);
+
+                await storageContext.DropTableAsync<UserModel4>();
+            }
+        }
+    }
+}

--- a/CoreHelpers.WindowsAzure.Storage.Table.Tests/Models/UserModel4.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table.Tests/Models/UserModel4.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using CoreHelpers.WindowsAzure.Storage.Table.Attributes;
+
+namespace CoreHelpers.WindowsAzure.Storage.Table.Tests.Models
+{
+
+    public enum UserTypeEnum
+    {
+        Free,
+        Pro
+    }
+
+    [Storable()]
+    public class UserModel4
+    {
+        [PartitionKey]
+        public string P { get; set; } = "Partition01";
+
+        [RowKey]
+        public string Contact { get; set; } = String.Empty;
+
+        public string FirstName { get; set; } = String.Empty;
+        public string LastName { get; set; } = String.Empty;
+
+        [StoreEnumAsString]
+        public UserTypeEnum UserType { get; set; }
+
+    }
+}

--- a/CoreHelpers.WindowsAzure.Storage.Table/Attributes/StoreEnumAsStringAttribute.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Attributes/StoreEnumAsStringAttribute.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections;
+using System.Reflection;
+using CoreHelpers.WindowsAzure.Storage.Table.Serialization;
+using Newtonsoft.Json;
+
+namespace CoreHelpers.WindowsAzure.Storage.Table.Attributes
+{
+	[AttributeUsage(AttributeTargets.Property)]
+	public class StoreEnumAsStringAttribute : Attribute, IVirtualTypeAttribute
+    {	
+		protected Type ObjectType { get; set; }
+		
+		public StoreEnumAsStringAttribute() 
+		{}
+			
+		public StoreEnumAsStringAttribute(Type objectType) 
+		{
+			ObjectType = objectType;
+		}
+			
+        public void WriteProperty<T>(PropertyInfo propertyInfo, T obj, TableEntityBuilder builder)
+        {
+            // get the value 
+            var element = propertyInfo.GetValue(obj);
+            if (element == null)
+                return;
+
+            // convert to strong 
+            var stringifiedElement = (element as Enum)?.ToString("F");
+
+			// add the property
+			builder.AddProperty(propertyInfo.Name, stringifiedElement);
+        }
+
+        public void ReadProperty<T>(Azure.Data.Tables.TableEntity dataObject, PropertyInfo propertyInfo, T obj)
+        {
+			// check if we have the property in our entity othetwise move forward
+			if (!dataObject.ContainsKey(propertyInfo.Name))
+				return;
+
+            // get the string value
+            var stringValue = Convert.ToString(dataObject[propertyInfo.Name]);
+
+			// prepare the value
+			var resultValue = Enum.Parse(propertyInfo.PropertyType, stringValue);
+
+
+			// set the value
+			propertyInfo.SetValue(obj, resultValue);
+        }
+    }
+}

--- a/CoreHelpers.WindowsAzure.Storage.Table/Attributes/StoreEnumAsStringAttribute.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Attributes/StoreEnumAsStringAttribute.cs
@@ -42,12 +42,19 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Attributes
             // get the string value
             var stringValue = Convert.ToString(dataObject[propertyInfo.Name]);
 
-			// prepare the value
-			var resultValue = Enum.Parse(propertyInfo.PropertyType, stringValue);
+            // Handle null/empty stored values quickly
+            // Nullable type would be defaulted to null already
+            // non-nullable cannot be set to null
+            if (string.IsNullOrEmpty(stringValue))
+                return;
 
+            // Support nullable enum properties by parsing against the underlying enum type
+            var propType = propertyInfo.PropertyType;
+            var enumType = Nullable.GetUnderlyingType(propType) ?? propType;
 
-			// set the value
-			propertyInfo.SetValue(obj, resultValue);
+            // Parse the enum stringValue name (stored as string) using the resolved enum type
+            var parsed = Enum.Parse(enumType, stringValue);
+            propertyInfo.SetValue(obj, parsed);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -143,6 +143,29 @@ public class VDictionaryModel
 }
 ```
 
+## Store Enum as String Attribute
+The store enum as string attribute allows to store enum values as string in Azure Table Store with the following code: 
+
+```csharp
+[Storable(Tablename: "EnumModel")]
+public class EnumtModel
+{
+
+ public enum TestEnum
+ {
+  First,
+  Second
+ }
+
+ [PartitionKey]
+ [RowKey]
+ public string UUID { get; set; }
+ 
+ [StoreEnumAsString]
+ public TestEnum Data { get; set; };
+}
+```
+
 ## Store as JSON Object Attribute
 The store as JSON attribute allows to store refenrenced objects as json payload for a specific property
  


### PR DESCRIPTION
Convert enum to string, and allow for ints to be converted to enums if they match an enum value. This PR makes it opt-in via attribute conversion.

```csharp
[StoreEnumAsString]
```

Replaces #11 and #22